### PR TITLE
Threaded execution

### DIFF
--- a/sshproxy/__init__.py
+++ b/sshproxy/__init__.py
@@ -91,7 +91,3 @@ def main():
             prompt_thread = threaded_quit_prompt()
             while prompt_thread.is_alive() and not ssh_error_event.is_set():
                 prompt_thread.join(0.5)
-
-
-if __name__ == '__main__':
-    main()

--- a/sshproxy/__main__.py
+++ b/sshproxy/__main__.py
@@ -1,0 +1,2 @@
+import sshproxy
+sshproxy.main()


### PR DESCRIPTION
Spawn a thread to wait for SSH command completion and crash the program if it returns with non-zero code. Previously, if SSH failed, the error would be ignored silently.